### PR TITLE
Added manifest file to support usage through pre-commit manager

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,8 @@
+# This file is a pre-commit manifest for the git hooks provided by this repository,
+# for use through the pre-commit tool/framework for git hooks management.
+# This enables a pre-commit configuration in another git repository(or which may be private to a user's checkout)
+# to simply reference these git hooks in order for them to be provided and configured by the pre-commit tool.
+# See https://pre-commit.com/
 - id: wazo-copyright-check
   name: check copyright notices
   description: check wazo copyright notices in source file headers of updated file

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,18 @@
+- id: wazo-copyright-check
+  name: check copyright notices
+  description: check wazo copyright notices in source file headers of updated file
+  language: script
+  entry: git-hooks/copyright-check
+  stages: [commit, push, manual]
+- id: wazo-changelog-check
+  name: update debian changelog
+  description: check that debian/changelog file has been updated along with commit
+  language: script
+  entry: git-hooks/changelog-check
+  stages: [commit, push, manual]
+- id: wazo-local-docker-volume-check
+  name: check local docker volume
+  description: check usage of LOCAL_GIT_REPOS in files to commit
+  language: script
+  entry: git-hooks/local-docker-volume-check
+  stages: [commit, push, manual]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
   ```
 
 ## git hooks
-Git hook scripts are provided in the git-hooks subdirectory.
-They can be installed manually(see [git-hooks/README.md](git-hooks/README.md)).
-They are also made available for use through the [pre-commit framework](https://pre-commit.com/) thanks to the .pre-commit-hooks.yml manifest file.
+Git hook scripts are provided in the `git-hooks` subdirectory.
+They can be installed manually (see [`git-hooks/README.md`](git-hooks/README.md)).
+They are also made available for use through the [pre-commit framework](https://pre-commit.com/) thanks to the `.pre-commit-hooks.yml` manifest file.
 
 A sample pre-commit configuration to use those hooks:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@
   set -o pipefail  # fail if command before pipe fails
   ```
 
+## git hooks
+Git hook scripts are provided in the git-hooks subdirectory.
+They can be installed manually(see [git-hooks/README.md](git-hooks/README.md)).
+They are also made available for use through the [pre-commit framework](https://pre-commit.com/) thanks to the .pre-commit-hooks.yml manifest file.
+
+A sample pre-commit configuration to use those hooks:
+```yaml
+# File .pre-commit-config.yaml
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/wazo-platform/wazo-tools.git
+  # pre-commit will complain about mutable reference, a specific tag or commit hash can be used instead
+  rev: master 
+  hooks:
+  - id: wazo-copyright-check
+  - id: wazo-changelog-check
+  - id: wazo-local-docker-volume-check
+```
+
 # TODO
 
 * move `./dev-tools/repos` to release repository


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a git hooks manager. 
It supports usage and management of multiple pre-commit hooks, including installation and configuration of hooks from external repositories.
Hooks to be used in a repository can be described in a `.pre-commit-config.yaml` file. 
If the config is present in the repository, an invocation of `pre-commit install --install-hooks` makes sure to install the hooks specified in that config. New contributors can then easily have the recommended hooks configured through this single invocation.

In order for git hooks to be made available through pre-commit, the repository hosting the hook scripts simply needs to include at the root a `.pre-commit-hooks.yaml` manifest that describes the hooks(most importantly, how they can be installed and used).

Using the manifest included in this PR, a simple `.pre-commit-config.yaml` to use those hooks might look like this:
```
# See https://pre-commit.com for more information
# See https://pre-commit.com/hooks.html for more hooks
repos:
- repo: https://github.com/wazo-platform/wazo-tools.git
  rev: master
  hooks:
  - id: wazo-copyright-check
  - id: wazo-changelog-check
  - id: wazo-local-docker-volume-check
```

Note: pre-commit supports different ways to install and use a hook. This version of the manifest uses the `script` language, which treats the hook files as arbitrary executable script with no managed dependencies. If the hooks were more complex and required dependencies outside a standard python installation, using the `python` language would enable the use of virtualenv to install and run the hooks with its dependencies.