### PR TITLE
hook: add pass_filenames to pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,16 +8,19 @@
   description: check wazo copyright notices in source file headers of updated file
   language: script
   entry: git-hooks/copyright-check
+  pass_filenames: false
   stages: [commit, push, manual]
 - id: wazo-changelog-check
   name: update debian changelog
   description: check that debian/changelog file has been updated along with commit
   language: script
   entry: git-hooks/changelog-check
+  pass_filenames: false
   stages: [commit, push, manual]
 - id: wazo-local-docker-volume-check
   name: check local docker volume
   description: check usage of LOCAL_GIT_REPOS in files to commit
   language: script
   entry: git-hooks/local-docker-volume-check
+  pass_filenames: false
   stages: [commit, push, manual]


### PR DESCRIPTION
why: normal workflow will execute command for each updated file found.
But executing command multiple time can result in very weird behavior
(ex: deleting entire file for copyright-check)
Passing pass_filenames: false will only execute the command one