### PR TITLE
use docker compose without hyphen command

### DIFF
--- a/compare-db/README.md
+++ b/compare-db/README.md
@@ -3,9 +3,7 @@
 ## Prerequisites
 
 ```sh
-apt-get install docker-ce
-curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-chmod +x ~/.docker/cli-plugins/docker-compose
+apt-get install docker-ce docker-compose-plugin
 pip install -r requirements.txt
 ```
 
@@ -14,14 +12,14 @@ pip install -r requirements.txt
 1. Start 2 PostgreSQL instances, e.g. with Docker
 
     ```sh
-    docker-compose up -d
+    docker compose up -d
     ```
 
 2. Get PostgreSQL ports from Docker
 
     ```sh
-    docker-compose port postgresql-migrated 5432
-    docker-compose port postgresql-installed 5432
+    docker compose port postgresql-migrated 5432
+    docker compose port postgresql-installed 5432
     ```
 
 3. Copy `defaults.ini` to `local.ini` and edit it to set the correct values. If you

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -4,7 +4,7 @@ tooling for integration testing workflows
 ## shell.sh
 Wraps common tasks to work with integration tests by providing a prepared subshell
 * activates a virtual environment and ensure the test python dependencies are installed
-* source `denv` into the shell, and runs `denv enter $asset` to deploy the integration tests setup using docker-compose
+* source `denv` into the shell, and runs `denv enter $asset` to deploy the integration tests setup using docker compose
 * automatically cleanup before exit by running `denv exit $asset`
 
 Example usage:

--- a/integration-tests/shell.sh
+++ b/integration-tests/shell.sh
@@ -16,7 +16,7 @@ source ${_venv}/bin/activate
 ${_venv}/bin/python -m pip install -r test-requirements.txt
 
 # other system dependencies assumed available for integration tests:
-# * docker-compose
+# * docker compose
 # * docker or equivalent
 
 # path to denv executable
@@ -35,7 +35,7 @@ function cleanup(){
     deactivate
 }
 
-# cleanup docker-compose environment on exit
+# cleanup docker compose environment on exit
 trap cleanup EXIT
 
 # execute command, defaulting to shell


### PR DESCRIPTION
why: it's now the recommended way to use docker compose